### PR TITLE
create simple .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# ignoring all hidden directories and files
+.*
+!/.gitignore
+
+# ignoring all __pycache__ folders
+**/__pycache__
+
+# ignoring the "results" directory
+results


### PR DESCRIPTION
I created a simple .gitignore file that will help manage version control. Notably, it prevents users from uploading files from the (heavy) ```results``` directory. Hidden files are also ignored (as some IDEs tend to generate hidden directories or files, such as the ```.idea/``` folder automatically generated by PyCharm for example). 