### PR TITLE
modify np.int -> int

### DIFF
--- a/data/preprocessor.py
+++ b/data/preprocessor.py
@@ -34,7 +34,7 @@ class preprocess(object):
             assert False, 'error'
 
         self.gt = np.genfromtxt(label_path, delimiter=delimiter, dtype=str)
-        frames = self.gt[:, 0].astype(np.float32).astype(np.int)
+        frames = self.gt[:, 0].astype(np.float32).astype(int)
         fr_start, fr_end = frames.min(), frames.max()
         self.init_frame = fr_start
         self.num_fr = fr_end + 1 - fr_start
@@ -88,7 +88,7 @@ class preprocess(object):
         return valid_id
 
     def get_pred_mask(self, cur_data, valid_id):
-        pred_mask = np.zeros(len(valid_id), dtype=np.int)
+        pred_mask = np.zeros(len(valid_id), dtype=int)
         for i, idx in enumerate(valid_id):
             pred_mask[i] = cur_data[cur_data[:, 1] == idx].squeeze()[-1]
         return pred_mask


### PR DESCRIPTION
I modified the code in ```preprocessor.py```. instances of ```np.int``` have been replaced by ```int```. This is done in accordance with the release notes of numpy version 1.20.0, stating the deprecation of the ```np.int``` datatype:
https://numpy.org/devdocs/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated

the modification does not alter the behaviour of the code in any way, but will reduce the amount of warning messages. Note that it also complies with the minimal case where the user has installed python version 3.7, and pip installed the ```requirements.txt``` file. In that case, the installed numpy version is superior to 1.20.0, ensuring that the code will function properly.